### PR TITLE
Add mini-survey slide mock pages with shared CSS

### DIFF
--- a/test/panel/public/mini-survey-slide-00-overview.html
+++ b/test/panel/public/mini-survey-slide-00-overview.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート概要</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="header">
+      <h1 class="title">ミニアンケートへようこそ</h1>
+      <p class="subtitle">回答前に概要をご確認ください。</p>
+      <div class="progress-wrap">
+        <div class="progress-meta"><span>開始前</span><span>0%</span></div>
+        <div class="progress"><span style="width: 0%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">イントロ</span>
+      <h2 class="question">このアンケートの目的と参加条件</h2>
+      <p class="help">本調査は、サービス品質向上のための意見収集を目的としています。</p>
+      <ul class="notice-list">
+        <li><strong>目的：</strong>ユーザー体験の改善に向けた基礎データの取得。</li>
+        <li><strong>質問数：</strong>全 <strong>1〜5問</strong> を予定（画面により変動）。</li>
+        <li><strong>回答条件：</strong><strong>全問必須</strong>で回答してください。</li>
+        <li><strong>謝礼：</strong>回答完了で <span class="strong">100pt</span> を付与します。</li>
+        <li><strong>参加回数：</strong><strong>1人1回</strong> までです。</li>
+      </ul>
+      <div class="footer">
+        <button class="btn" type="button">アンケートを開始する</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-01-single.html
+++ b/test/panel/public/mini-survey-slide-01-single.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 単一選択</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問1/4：最も近いものを1つ選択してください。</p>
+      <div class="progress-wrap">
+        <div class="progress-meta"><span>進捗</span><span>25%</span></div>
+        <div class="progress"><span style="width: 25%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Single Choice</span>
+      <h2 class="question">Q1. あなたが最もよく利用する機能はどれですか？</h2>
+      <p class="help">以下から1つ選択してください（必須）。</p>
+      <div class="field-list">
+        <label class="option"><input type="radio" name="single" required />ダッシュボード</label>
+        <label class="option"><input type="radio" name="single" />アンケート一覧</label>
+        <label class="option"><input type="radio" name="single" />ポイント履歴</label>
+        <label class="option"><input type="radio" name="single" />プロフィール設定</label>
+      </div>
+      <div class="footer">
+        <button class="btn" type="button">回答して次へ</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-02-multi.html
+++ b/test/panel/public/mini-survey-slide-02-multi.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 複数選択</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問2/4：あてはまる項目をすべて選択してください。</p>
+      <div class="progress-wrap">
+        <div class="progress-meta"><span>進捗</span><span>50%</span></div>
+        <div class="progress"><span style="width: 50%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Multiple Choice</span>
+      <h2 class="question">Q2. このサービスの改善に有効だと思う要素を選んでください。</h2>
+      <p class="help">複数選択可能です（1つ以上必須）。</p>
+      <div class="field-list">
+        <label class="option"><input type="checkbox" name="multi" />検索機能の強化</label>
+        <label class="option"><input type="checkbox" name="multi" />通知のカスタマイズ</label>
+        <label class="option"><input type="checkbox" name="multi" />モバイル表示の最適化</label>
+        <label class="option"><input type="checkbox" name="multi" />回答履歴の可視化</label>
+      </div>
+      <div class="footer">
+        <button class="btn" type="button">回答して次へ</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-03-open-end.html
+++ b/test/panel/public/mini-survey-slide-03-open-end.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 自由記述</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問3/4：ご意見を自由にご記入ください。</p>
+      <div class="progress-wrap">
+        <div class="progress-meta"><span>進捗</span><span>75%</span></div>
+        <div class="progress"><span style="width: 75%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Open End</span>
+      <h2 class="question">Q3. サービスをより使いやすくするためのご要望を教えてください。</h2>
+      <p class="help">具体的な場面や期待する改善内容があればご記入ください（必須）。</p>
+      <textarea required placeholder="例：アンケートの検索条件を保存できると便利です。"></textarea>
+      <div class="footer">
+        <button class="btn" type="button">回答して次へ</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-04-numeric.html
+++ b/test/panel/public/mini-survey-slide-04-numeric.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 数値入力</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問4/4：数値をご入力ください。</p>
+      <div class="progress-wrap">
+        <div class="progress-meta"><span>進捗</span><span>100%</span></div>
+        <div class="progress"><span style="width: 100%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Numeric</span>
+      <h2 class="question">Q4. あなたの総合満足度を数値で評価してください。</h2>
+      <p class="help">0〜10の範囲で、整数または小数第1位まで入力できます（必須）。</p>
+      <div class="number-group">
+        <input type="number" min="0" max="10" step="0.1" required placeholder="例：8.5" />
+        <span class="unit">点 / 10点満点</span>
+      </div>
+      <p class="limits">入力範囲: 最小0 / 最大10</p>
+      <div class="footer">
+        <button class="btn" type="button">回答を送信する</button>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slides.css
+++ b/test/panel/public/mini-survey-slides.css
@@ -1,0 +1,210 @@
+:root {
+  --bg: #f3f6fb;
+  --card: #ffffff;
+  --line: #dce3ef;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --accent: #e8f0ff;
+  --success: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  background: linear-gradient(180deg, #f8fbff 0%, var(--bg) 100%);
+  color: var(--text);
+}
+
+.page {
+  max-width: 760px;
+  margin: 32px auto;
+  padding: 0 16px 40px;
+}
+
+.header {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 18px 20px;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.06);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.progress-wrap {
+  margin-top: 14px;
+}
+
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.progress {
+  margin-top: 6px;
+  height: 10px;
+  width: 100%;
+  background: #e6ebf5;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress > span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary), #4f8cff);
+}
+
+.card {
+  margin-top: 16px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.06);
+}
+
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: var(--primary-dark);
+  border: 1px solid #bfd2ff;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.question {
+  margin: 12px 0 6px;
+  font-size: 1.15rem;
+}
+
+.help {
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.field-list {
+  display: grid;
+  gap: 10px;
+}
+
+.option {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.option:hover {
+  border-color: #9db8f8;
+  background: #f8fbff;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+  margin-top: 2px;
+  transform: scale(1.15);
+}
+
+textarea,
+input[type="number"] {
+  width: 100%;
+  border: 1px solid #bfc8d8;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+textarea:focus,
+input[type="number"]:focus {
+  outline: 2px solid #bdd5ff;
+  border-color: #6fa1ff;
+}
+
+.number-group {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.unit {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.limits {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.footer {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: none;
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--primary);
+  cursor: pointer;
+  transition: transform 0.05s, background 0.2s;
+}
+
+.btn:hover {
+  background: var(--primary-dark);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.notice-list {
+  margin: 14px 0 0;
+  padding-left: 18px;
+  color: #374151;
+}
+
+.notice-list li + li {
+  margin-top: 8px;
+}
+
+.strong {
+  color: var(--success);
+  font-weight: 700;
+}


### PR DESCRIPTION
### Motivation
- Provide a set of self-contained HTML mockups for a mini survey flow with a consistent, "real-web" layout to use for demos and manual QA.
- Support four common question types (single, multi, open-end, numeric) plus an intro screen that documents purpose/constraints and reward information.
- Keep presentation consistent by extracting shared visuals into a single CSS file so pages are easy to maintain and iterate.

### Description
- Added a shared stylesheet `test/panel/public/mini-survey-slides.css` that defines page tone, header, progress bar, question card, input styles, and buttons.
- Added an intro page `test/panel/public/mini-survey-slide-00-overview.html` that states purpose, question count (1–5), all-required, 100pt reward, and one-time participation.
- Added four slide HTML mockups under `test/panel/public/`: `mini-survey-slide-01-single.html` (radio single choice), `mini-survey-slide-02-multi.html` (checkbox multiple choice), `mini-survey-slide-03-open-end.html` (textarea free text), and `mini-survey-slide-04-numeric.html` (number input with `min/max/step` and unit display).
- Each page uses the shared CSS and includes header, progress indicator, question card, answer controls, and a submit/next button to reflect the requested UX.

### Testing
- Ran a Python assertion script that verified each new file includes the shared CSS and that pages contain the expected input types and intro tokens, and it passed with message `mini survey slide checks: OK`.
- Launched a static server with `python -m http.server --directory test/panel/public` and validated rendering by capturing a screenshot of the single-choice page with a Playwright script, which completed successfully and produced an artifact image.
- All automated checks and visual validation steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69893aff15e88331bc445ca5e8dcea41)