### PR TITLE
Add mini survey schema, completion transaction, notifications, and CSV export

### DIFF
--- a/test/panel/backend/README.md
+++ b/test/panel/backend/README.md
@@ -1,0 +1,38 @@
+# Mini Survey Backend Implementation
+
+このディレクトリに、ミニサーベイ向けのバックエンド実装（SQL設計・トランザクション処理・CSV整形）を追加しました。
+
+## 追加内容
+
+- `migrations/001_create_mini_survey_tables.sql`
+  - 以下のテーブルを作成
+    - `mini_survey`
+    - `mini_survey_question`
+    - `mini_survey_option`
+    - `mini_survey_response`（`member_id`, `status`, `started_at`, `completed_at` を含む）
+    - `mini_survey_answer`（`question_id`, `answer_value_json` を含む）
+    - `mini_survey_response_snapshot`
+  - スナップショット属性は最低限 `member_id/specialty/hospital_type/prefecture/years_in_practice` を保持。
+  - `facility_size` は仕様会議での最終確定を前提に nullable で先行追加。
+
+- `src/miniSurveyService.js`
+  - 公開時通知: `publishMiniSurvey`
+  - 回答完了トランザクション: `completeMiniSurveyResponse`
+    - `point_ledger` に `reason = mini_survey_complete`, `survey_id` を記録
+    - 100pt を即時付与
+    - 同一トランザクションで回答完了通知を追加
+  - CSVエクスポート整形: `buildMiniSurveyCsv`
+    - 「1行=回答者×サーベイ（1人1回）」
+    - 「列=属性スナップショット+各設問回答」
+
+- `test/miniSurveyService.test.js`
+  - トランザクション内で必要な SQL が発行されることを確認
+  - CSV整形の列順・内容保証を確認
+
+## 実行
+
+```bash
+npm test
+```
+
+（`test/panel` 配下で実行）

--- a/test/panel/backend/migrations/001_create_mini_survey_tables.sql
+++ b/test/panel/backend/migrations/001_create_mini_survey_tables.sql
@@ -1,0 +1,80 @@
+BEGIN;
+
+CREATE TABLE mini_survey (
+  id BIGSERIAL PRIMARY KEY,
+  code VARCHAR(64) NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  description TEXT,
+  status VARCHAR(32) NOT NULL DEFAULT 'draft',
+  published_at TIMESTAMPTZ,
+  close_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE mini_survey_question (
+  id BIGSERIAL PRIMARY KEY,
+  survey_id BIGINT NOT NULL REFERENCES mini_survey(id) ON DELETE CASCADE,
+  question_order INTEGER NOT NULL,
+  question_type VARCHAR(32) NOT NULL,
+  body TEXT NOT NULL,
+  required BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (survey_id, question_order)
+);
+
+CREATE TABLE mini_survey_option (
+  id BIGSERIAL PRIMARY KEY,
+  question_id BIGINT NOT NULL REFERENCES mini_survey_question(id) ON DELETE CASCADE,
+  option_order INTEGER NOT NULL,
+  value VARCHAR(255) NOT NULL,
+  label TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (question_id, option_order)
+);
+
+CREATE TABLE mini_survey_response (
+  id BIGSERIAL PRIMARY KEY,
+  survey_id BIGINT NOT NULL REFERENCES mini_survey(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL,
+  status VARCHAR(32) NOT NULL DEFAULT 'started',
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (survey_id, member_id)
+);
+
+CREATE TABLE mini_survey_answer (
+  id BIGSERIAL PRIMARY KEY,
+  response_id BIGINT NOT NULL REFERENCES mini_survey_response(id) ON DELETE CASCADE,
+  question_id BIGINT NOT NULL REFERENCES mini_survey_question(id) ON DELETE CASCADE,
+  answer_value_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (response_id, question_id)
+);
+
+CREATE TABLE mini_survey_response_snapshot (
+  id BIGSERIAL PRIMARY KEY,
+  response_id BIGINT NOT NULL UNIQUE REFERENCES mini_survey_response(id) ON DELETE CASCADE,
+  member_id BIGINT NOT NULL,
+  specialty VARCHAR(255) NOT NULL,
+  hospital_type VARCHAR(255) NOT NULL,
+  prefecture VARCHAR(64) NOT NULL,
+  years_in_practice INTEGER NOT NULL,
+  facility_size VARCHAR(64), -- optional, to be finalized in a spec meeting.
+  snapshot_taken_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX mini_survey_response_survey_id_status_idx
+  ON mini_survey_response (survey_id, status);
+
+CREATE INDEX mini_survey_answer_response_id_idx
+  ON mini_survey_answer (response_id);
+
+COMMIT;

--- a/test/panel/backend/src/miniSurveyService.js
+++ b/test/panel/backend/src/miniSurveyService.js
@@ -1,0 +1,110 @@
+const COMPLETE_REASON = 'mini_survey_complete';
+const COMPLETE_POINTS = 100;
+
+/**
+ * Publishes a survey and creates a notification for all members.
+ * `db` is expected to provide `query(sql, params)` and transaction support.
+ */
+export async function publishMiniSurvey({ db, surveyId, publishedAt = new Date() }) {
+  return db.transaction(async (trx) => {
+    await trx.query(
+      `UPDATE mini_survey
+       SET status = 'published', published_at = $2, updated_at = NOW()
+       WHERE id = $1`,
+      [surveyId, publishedAt],
+    );
+
+    await trx.query(
+      `INSERT INTO notification (kind, title, body, related_survey_id, created_at)
+       VALUES ('mini_survey_published', '新しいミニサーベイが公開されました', '回答受付を開始しました。', $1, NOW())`,
+      [surveyId],
+    );
+  });
+}
+
+/**
+ * Completes one response and records points/notification in the same transaction.
+ */
+export async function completeMiniSurveyResponse({
+  db,
+  surveyId,
+  responseId,
+  memberId,
+  completedAt = new Date(),
+}) {
+  return db.transaction(async (trx) => {
+    await trx.query(
+      `UPDATE mini_survey_response
+       SET status = 'completed', completed_at = $2, updated_at = NOW()
+       WHERE id = $1 AND member_id = $3`,
+      [responseId, completedAt, memberId],
+    );
+
+    await trx.query(
+      `INSERT INTO point_ledger (member_id, reason, points, survey_id, created_at)
+       VALUES ($1, $2, $3, $4, NOW())`,
+      [memberId, COMPLETE_REASON, COMPLETE_POINTS, surveyId],
+    );
+
+    await trx.query(
+      `INSERT INTO notification (member_id, kind, title, body, related_survey_id, created_at)
+       VALUES ($1, 'mini_survey_completed', 'ミニサーベイ回答完了', '100ptを付与しました。', $2, NOW())`,
+      [memberId, surveyId],
+    );
+  });
+}
+
+function safeCsv(value) {
+  const raw = value == null ? '' : String(value);
+  const escaped = raw.replaceAll('"', '""');
+  return `"${escaped}"`;
+}
+
+/**
+ * Exports 1 row per (member x survey) with flattened snapshot + answers.
+ */
+export function buildMiniSurveyCsv({ snapshots, questions, responses }) {
+  const questionColumns = questions
+    .sort((a, b) => a.questionOrder - b.questionOrder)
+    .map((q) => ({ id: q.id, key: `q_${q.questionOrder}` }));
+
+  const header = [
+    'survey_id',
+    'response_id',
+    'member_id',
+    'specialty',
+    'hospital_type',
+    'prefecture',
+    'years_in_practice',
+    'facility_size',
+    ...questionColumns.map((x) => x.key),
+  ];
+
+  const rows = responses.map((response) => {
+    const snapshot = snapshots.find((x) => x.responseId === response.id);
+    if (!snapshot) {
+      throw new Error(`snapshot missing for response_id=${response.id}`);
+    }
+
+    const answerMap = new Map(response.answers.map((a) => [a.questionId, JSON.stringify(a.answerValueJson)]));
+
+    return [
+      response.surveyId,
+      response.id,
+      snapshot.memberId,
+      snapshot.specialty,
+      snapshot.hospitalType,
+      snapshot.prefecture,
+      snapshot.yearsInPractice,
+      snapshot.facilitySize ?? '',
+      ...questionColumns.map((col) => answerMap.get(col.id) ?? ''),
+    ];
+  });
+
+  return [header, ...rows].map((line) => line.map(safeCsv).join(',')).join('\n');
+}
+
+export const constants = {
+  COMPLETE_REASON,
+  COMPLETE_POINTS,
+};

--- a/test/panel/backend/test/miniSurveyService.test.js
+++ b/test/panel/backend/test/miniSurveyService.test.js
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildMiniSurveyCsv,
+  completeMiniSurveyResponse,
+  constants,
+  publishMiniSurvey,
+} from '../src/miniSurveyService.js';
+
+function createMockDb() {
+  const calls = [];
+  const trx = {
+    query: async (sql, params) => {
+      calls.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
+    },
+  };
+  return {
+    calls,
+    transaction: async (fn) => fn(trx),
+  };
+}
+
+test('completeMiniSurveyResponse records completion, points and notification in one transaction', async () => {
+  const db = createMockDb();
+
+  await completeMiniSurveyResponse({
+    db,
+    surveyId: 9,
+    responseId: 12,
+    memberId: 1001,
+    completedAt: new Date('2026-02-01T00:00:00Z'),
+  });
+
+  assert.equal(db.calls.length, 3);
+  assert.match(db.calls[0].sql, /UPDATE mini_survey_response/);
+  assert.match(db.calls[1].sql, /INSERT INTO point_ledger/);
+  assert.deepEqual(db.calls[1].params, [1001, constants.COMPLETE_REASON, constants.COMPLETE_POINTS, 9]);
+  assert.match(db.calls[2].sql, /INSERT INTO notification/);
+});
+
+test('publishMiniSurvey updates status and inserts publish notification', async () => {
+  const db = createMockDb();
+
+  await publishMiniSurvey({ db, surveyId: 5, publishedAt: new Date('2026-01-01T00:00:00Z') });
+
+  assert.equal(db.calls.length, 2);
+  assert.match(db.calls[0].sql, /UPDATE mini_survey/);
+  assert.match(db.calls[1].sql, /mini_survey_published/);
+});
+
+test('buildMiniSurveyCsv guarantees one row per response and ordered question columns', () => {
+  const csv = buildMiniSurveyCsv({
+    snapshots: [
+      {
+        responseId: 300,
+        memberId: 88,
+        specialty: 'cardiology',
+        hospitalType: 'university',
+        prefecture: 'tokyo',
+        yearsInPractice: 12,
+        facilitySize: '500+',
+      },
+    ],
+    questions: [
+      { id: 20, questionOrder: 2 },
+      { id: 10, questionOrder: 1 },
+    ],
+    responses: [
+      {
+        id: 300,
+        surveyId: 55,
+        answers: [
+          { questionId: 10, answerValueJson: { value: 'A' } },
+          { questionId: 20, answerValueJson: ['x', 'y'] },
+        ],
+      },
+    ],
+  });
+
+  const [header, data] = csv.split('\n');
+  assert.match(header, /"q_1","q_2"$/);
+  assert.match(data, /"55","300","88"/);
+  assert.match(data, /"{""value"":""A""}"/);
+});
+
+test('buildMiniSurveyCsv fails when snapshot is missing', () => {
+  assert.throws(
+    () =>
+      buildMiniSurveyCsv({
+        snapshots: [],
+        questions: [],
+        responses: [{ id: 1, surveyId: 1, answers: [] }],
+      }),
+    /snapshot missing/,
+  );
+});

--- a/test/panel/package.json
+++ b/test/panel/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test backend/test/*.test.js"
   },
   "dependencies": {
     "react": "^19.2.0",


### PR DESCRIPTION
### Motivation
- Provide a backend implementation for a lightweight survey feature including DB schema, transactional completion/point awarding, notifications, and CSV export so surveys can be published and respondents rewarded reliably.
- Ensure member attribute snapshots are captured at response time for reproducible exports and analytics, and allow one optional snapshot field (`facility_size`) to be finalized later.

### Description
- Added a DB migration `migrations/001_create_mini_survey_tables.sql` that creates `mini_survey`, `mini_survey_question`, `mini_survey_option`, `mini_survey_response`, `mini_survey_answer`, and `mini_survey_response_snapshot` and indexes/constraints; snapshots store `member_id`, `specialty`, `hospital_type`, `prefecture`, `years_in_practice` and an optional `facility_size`.
- Implemented `publishMiniSurvey` and `completeMiniSurveyResponse` in `src/miniSurveyService.js` where publishing inserts a publish notification and completion runs in one transaction that updates the response, inserts into `point_ledger` with `reason = mini_survey_complete` and `survey_id` and grants `100` points, and inserts a completion `notification`.
- Implemented `buildMiniSurveyCsv` in `src/miniSurveyService.js` to produce CSVs with one row per (member × survey) and columns composed of snapshot attributes followed by ordered question answer columns.
- Added unit tests `backend/test/miniSurveyService.test.js`, a `test` npm script in `package.json`, and a README `backend/README.md` describing the changes and how to run tests.

### Testing
- Ran `npm test` (configured as `node --test backend/test/*.test.js`) and all automated tests passed (4/4 tests OK).
- Ran linter via `npm run lint` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69893b033f5483319f41755a6ae7f543)