### PR TITLE
Add Mini Survey flow: dashboard cards, answer UI, routes and completion screen

### DIFF
--- a/test/panel/package-lock.json
+++ b/test/panel/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@tailwindcss/postcss": "^4.1.18",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
@@ -26,6 +27,19 @@
         "react-router-dom": "^7.12.0",
         "tailwindcss": "^4.1.18",
         "vite": "^7.2.4"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1368,6 +1382,277 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
+      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
+      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-x64": "4.1.18",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
+      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
+      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
+      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
+      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
+      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
+      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
+      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
+      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
+      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.18.tgz",
+      "integrity": "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.18",
+        "@tailwindcss/oxide": "4.1.18",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.18"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1773,12 +2058,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -2184,6 +2493,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2278,6 +2594,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2369,6 +2695,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2410,6 +2997,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -2838,6 +3435,20 @@
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/test/panel/package.json
+++ b/test/panel/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@tailwindcss/postcss": "^4.1.18",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/test/panel/postcss.config.js
+++ b/test/panel/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/test/panel/src/App.jsx
+++ b/test/panel/src/App.jsx
@@ -6,6 +6,8 @@ import Profile from './components/Profile'
 import Points from './components/Points'
 import Register from './components/Register'
 import AdminDashboard from './components/AdminDashboard'
+import MiniSurveyAnswer from './components/MiniSurveyAnswer'
+import MiniSurveyComplete from './components/MiniSurveyComplete'
 
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
@@ -53,6 +55,26 @@ function App() {
           element={
             isAuthenticated && userRole === 'user' ? (
               <Points onLogout={handleLogout} />
+            ) : (
+              <Navigate to="/login" />
+            )
+          }
+        />
+        <Route
+          path="/mini-survey/:surveyId"
+          element={
+            isAuthenticated && userRole === 'user' ? (
+              <MiniSurveyAnswer onLogout={handleLogout} />
+            ) : (
+              <Navigate to="/login" />
+            )
+          }
+        />
+        <Route
+          path="/mini-survey/:surveyId/complete"
+          element={
+            isAuthenticated && userRole === 'user' ? (
+              <MiniSurveyComplete onLogout={handleLogout} />
             ) : (
               <Navigate to="/login" />
             )

--- a/test/panel/src/components/Dashboard.jsx
+++ b/test/panel/src/components/Dashboard.jsx
@@ -83,6 +83,25 @@ function Dashboard({ onLogout }) {
     },
   ]
 
+  const miniSurveys = [
+    {
+      id: 'MS-2026-001',
+      title: '診療体制に関するミニ調査',
+      points: 100,
+      deadline: '2026-01-17',
+      duration: '約3分',
+      responseStatus: 'unanswered'
+    },
+    {
+      id: 'MS-2026-002',
+      title: '電子カルテ利用状況ミニアンケート',
+      points: 100,
+      deadline: '2026-01-16',
+      duration: '約2分',
+      responseStatus: 'answered'
+    },
+  ]
+
   return (
     <Layout onLogout={onLogout}>
       <div className="space-y-6">
@@ -121,7 +140,7 @@ function Dashboard({ onLogout }) {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* アンケート一覧 */}
           <div className="lg:col-span-2">
-            <div className="bg-white rounded-lg shadow">
+            <div className="bg-white rounded-lg shadow mb-6">
               <div className="px-6 py-4 border-b border-gray-200">
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-semibold text-gray-900 flex items-center">
@@ -166,6 +185,56 @@ function Dashboard({ onLogout }) {
                 <button className="text-primary-600 hover:text-primary-700 text-sm font-medium">
                   すべてのアンケートを見る →
                 </button>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow">
+              <div className="px-6 py-4 border-b border-gray-200">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-lg font-semibold text-gray-900 flex items-center">
+                    <FileText className="h-5 w-5 mr-2 text-primary-600" />
+                    Mini Survey新着カード
+                  </h2>
+                  <span className="bg-orange-100 text-orange-800 text-xs font-semibold px-2.5 py-0.5 rounded">
+                    {miniSurveys.length}件
+                  </span>
+                </div>
+              </div>
+              <div className="divide-y divide-gray-200">
+                {miniSurveys.map((survey) => (
+                  <div key={survey.id} className="p-6 hover:bg-gray-50 transition duration-150">
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <h3 className="text-base font-medium text-gray-900 mb-2">
+                          {survey.title}
+                        </h3>
+                        <div className="flex items-center space-x-4 text-sm text-gray-500">
+                          <span className="flex items-center">
+                            <Coins className="h-4 w-4 mr-1 text-yellow-500" />
+                            {survey.points}pt
+                          </span>
+                          <span className="flex items-center">
+                            <Calendar className="h-4 w-4 mr-1" />
+                            締切: {survey.deadline}
+                          </span>
+                          <span className="flex items-center">
+                            所要時間: {survey.duration}
+                          </span>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => navigate(`/mini-survey/${survey.id}`)}
+                        className={`ml-4 px-4 py-2 text-sm font-medium rounded-md transition duration-150 ${
+                          survey.responseStatus === 'answered'
+                            ? 'bg-gray-200 text-gray-500'
+                            : 'bg-primary-600 text-white hover:bg-primary-700'
+                        }`}
+                      >
+                        {survey.responseStatus === 'answered' ? '回答済み' : '回答する'}
+                      </button>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           </div>

--- a/test/panel/src/components/MiniSurveyAnswer.jsx
+++ b/test/panel/src/components/MiniSurveyAnswer.jsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { CheckCircle2, Coins } from 'lucide-react'
+import Layout from './Layout'
+
+const miniSurveyQuestionSet = [
+  {
+    id: 'q1',
+    type: 'single',
+    question: '現在の主な勤務形態を選択してください。',
+    options: ['病院勤務', 'クリニック勤務', 'その他']
+  },
+  {
+    id: 'q2',
+    type: 'multi',
+    question: '日常診療で重視している情報源をすべて選択してください。',
+    options: ['学会発表', '論文', '同僚医師の意見', '製薬企業の情報提供']
+  },
+  {
+    id: 'q3',
+    type: 'scale',
+    question: 'オンライン診療への関心度を教えてください。',
+    scaleMin: 1,
+    scaleMax: 5
+  },
+  {
+    id: 'q4',
+    type: 'text',
+    question: 'ミニサーベイに関するご意見があれば記載してください。'
+  }
+]
+
+function MiniSurveyAnswer({ onLogout }) {
+  const { surveyId } = useParams()
+  const navigate = useNavigate()
+
+  const [responseStatus, setResponseStatus] = useState(
+    surveyId === 'MS-2026-002' ? 'answered' : 'unanswered'
+  )
+  const [answers, setAnswers] = useState({ q1: '', q2: [], q3: '', q4: '' })
+  const [errors, setErrors] = useState({})
+
+  const isAnswered = responseStatus === 'answered'
+
+  const surveyTitle = useMemo(
+    () => `Mini Survey (${surveyId})`,
+    [surveyId]
+  )
+
+  const handleSingleAnswer = (questionId, value) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }))
+  }
+
+  const handleMultiAnswer = (questionId, value) => {
+    setAnswers((prev) => {
+      const currentValues = prev[questionId]
+      const updatedValues = currentValues.includes(value)
+        ? currentValues.filter((item) => item !== value)
+        : [...currentValues, value]
+
+      return { ...prev, [questionId]: updatedValues }
+    })
+  }
+
+  const validateAnswers = () => {
+    const validationErrors = {}
+
+    miniSurveyQuestionSet.forEach((question) => {
+      const answer = answers[question.id]
+
+      if (question.type === 'multi' && answer.length === 0) {
+        validationErrors[question.id] = '1つ以上選択してください。'
+      }
+
+      if (question.type !== 'multi' && String(answer).trim() === '') {
+        validationErrors[question.id] = 'この質問は必須です。'
+      }
+    })
+
+    setErrors(validationErrors)
+    return Object.keys(validationErrors).length === 0
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+
+    if (isAnswered) {
+      return
+    }
+
+    if (!validateAnswers()) {
+      return
+    }
+
+    setResponseStatus('answered')
+    navigate(`/mini-survey/${surveyId}/complete`, {
+      state: {
+        surveyId,
+        awardedPoints: 100
+      }
+    })
+  }
+
+  return (
+    <Layout onLogout={onLogout}>
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="bg-white rounded-lg shadow p-6">
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">{surveyTitle}</h1>
+          <p className="text-gray-600">質問にご回答ください（全問必須）</p>
+        </div>
+
+        <div className="bg-white rounded-lg shadow p-6 border border-primary-100">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-gray-700">回答ステータス</p>
+            <span className={`px-3 py-1 text-sm font-semibold rounded-full ${
+              isAnswered ? 'bg-gray-100 text-gray-700' : 'bg-emerald-100 text-emerald-700'
+            }`}>
+              {isAnswered ? '回答済み' : '未回答'}
+            </span>
+          </div>
+          {isAnswered && (
+            <p className="mt-3 text-sm text-gray-600 flex items-center">
+              <CheckCircle2 className="h-4 w-4 mr-1 text-green-600" />
+              このMini Surveyには既に回答済みです。
+            </p>
+          )}
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow divide-y divide-gray-200">
+          {miniSurveyQuestionSet.map((question, index) => (
+            <div key={question.id} className="p-6">
+              <p className="text-base font-semibold text-gray-900 mb-4">
+                Q{index + 1}. {question.question}
+              </p>
+
+              {question.type === 'single' && (
+                <div className="space-y-2">
+                  {question.options.map((option) => (
+                    <label key={option} className="flex items-center text-sm text-gray-700">
+                      <input
+                        type="radio"
+                        name={question.id}
+                        value={option}
+                        checked={answers[question.id] === option}
+                        onChange={() => handleSingleAnswer(question.id, option)}
+                        disabled={isAnswered}
+                        className="mr-2"
+                      />
+                      {option}
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              {question.type === 'multi' && (
+                <div className="space-y-2">
+                  {question.options.map((option) => (
+                    <label key={option} className="flex items-center text-sm text-gray-700">
+                      <input
+                        type="checkbox"
+                        value={option}
+                        checked={answers[question.id].includes(option)}
+                        onChange={() => handleMultiAnswer(question.id, option)}
+                        disabled={isAnswered}
+                        className="mr-2"
+                      />
+                      {option}
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              {question.type === 'scale' && (
+                <div className="flex items-center space-x-2">
+                  {Array.from(
+                    { length: question.scaleMax - question.scaleMin + 1 },
+                    (_, offset) => question.scaleMin + offset
+                  ).map((score) => (
+                    <button
+                      key={score}
+                      type="button"
+                      onClick={() => handleSingleAnswer(question.id, String(score))}
+                      disabled={isAnswered}
+                      className={`w-10 h-10 rounded-md border text-sm font-semibold ${
+                        answers[question.id] === String(score)
+                          ? 'bg-primary-600 border-primary-600 text-white'
+                          : 'bg-white border-gray-300 text-gray-700'
+                      }`}
+                    >
+                      {score}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {question.type === 'text' && (
+                <textarea
+                  value={answers[question.id]}
+                  onChange={(event) => handleSingleAnswer(question.id, event.target.value)}
+                  rows={4}
+                  disabled={isAnswered}
+                  placeholder="ご記入ください"
+                  className="w-full border border-gray-300 rounded-md p-3 text-sm focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                />
+              )}
+
+              {errors[question.id] && (
+                <p className="text-sm text-red-600 mt-3">{errors[question.id]}</p>
+              )}
+            </div>
+          ))}
+
+          <div className="p-6 bg-gray-50 flex items-center justify-between">
+            <p className="text-sm text-gray-600 flex items-center">
+              <Coins className="h-4 w-4 mr-1 text-yellow-500" />
+              回答完了で100pt付与
+            </p>
+            <button
+              type="submit"
+              disabled={isAnswered}
+              className={`px-6 py-2 rounded-md text-sm font-semibold ${
+                isAnswered
+                  ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                  : 'bg-primary-600 text-white hover:bg-primary-700'
+              }`}
+            >
+              {isAnswered ? '回答済み' : '送信する'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </Layout>
+  )
+}
+
+export default MiniSurveyAnswer

--- a/test/panel/src/components/MiniSurveyComplete.jsx
+++ b/test/panel/src/components/MiniSurveyComplete.jsx
@@ -1,0 +1,45 @@
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { CheckCircle2, Coins } from 'lucide-react'
+import Layout from './Layout'
+
+function MiniSurveyComplete({ onLogout }) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { surveyId } = useParams()
+
+  const awardedPoints = location.state?.awardedPoints ?? 100
+
+  return (
+    <Layout onLogout={onLogout}>
+      <div className="max-w-2xl mx-auto bg-white rounded-lg shadow p-8 text-center">
+        <CheckCircle2 className="h-14 w-14 text-green-600 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-900 mb-3">回答ありがとうございました</h1>
+        <p className="text-gray-600 mb-6">
+          Mini Survey（{surveyId}）の回答を受け付けました。
+        </p>
+
+        <div className="inline-flex items-center px-6 py-3 rounded-lg bg-yellow-50 border border-yellow-200 text-yellow-800 font-semibold mb-8">
+          <Coins className="h-5 w-5 mr-2 text-yellow-500" />
+          付与ポイント: {awardedPoints}pt
+        </div>
+
+        <div className="flex justify-center gap-3">
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="px-5 py-2 rounded-md bg-primary-600 text-white text-sm font-semibold hover:bg-primary-700"
+          >
+            ダッシュボードへ戻る
+          </button>
+          <button
+            onClick={() => navigate(`/mini-survey/${surveyId}`)}
+            className="px-5 py-2 rounded-md bg-gray-100 text-gray-700 text-sm font-semibold hover:bg-gray-200"
+          >
+            回答内容を確認
+          </button>
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default MiniSurveyComplete


### PR DESCRIPTION
### Motivation

- ダッシュボードに短時間で回答できる「Mini Survey」を追加して参加率を高め、既存のUI体系に合わせて自然に表示するための実装です。 
- 回答フローは必須バリデーションや回答済み制御を備え、開発・実行時に発生した Tailwind/PostCSS の設定問題も解消して確実にビルドできる状態とするための修正を含みます。

### Description

- `test/panel/src/components/Dashboard.jsx` に `Mini Survey新着カード` セクションを追加し、未回答は `回答する`、回答済みは `回答済み` を表示するようにしました。 
- ルーティングに ` /mini-survey/:surveyId`（回答画面）と ` /mini-survey/:surveyId/complete`（完了画面）を追加し、`test/panel/src/App.jsx` を更新して既存の認証ガードに合わせました。 
- 新規ファイル `test/panel/src/components/MiniSurveyAnswer.jsx` を作成し、質問タイプごとに UI を切替（単一選択/複数選択/スケール/自由記述）しつつ全問必須バリデーションを実装し、回答済み時は入力を無効化する `responseStatus` 制御を導入しました。 
- 新規ファイル `test/panel/src/components/MiniSurveyComplete.jsx` を作成し、送信成功時に完了画面へ遷移して `100pt` を明示表示するようにしました。 
- ビルド不具合を解消するために `@tailwindcss/postcss` を導入し `test/panel/postcss.config.js` を更新、`test/panel/package.json` と `package-lock.json` を更新してローカルでのビルドが通るようにしました。 

### Testing

- 実行した自動検査は `cd test/panel && npm run lint` で ESLint を実行し正常終了しました（OK）。
- ビルド検証は `cd test/panel && npm run build` を実行し、最初に出た Tailwind/PostCSS のエラーを `@tailwindcss/postcss` 導入と `postcss.config.js` 更新で解消してビルドが成功しました（OK）。
- UI の簡易自動操作は Playwright スクリプトでログイン→`/dashboard`→`/mini-survey/MS-2026-001` へ遷移してスクリーンショットを取得しており、主要画面の表示を自動確認した成果物（スクリーンショット）が作成されています（OK）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69893b01e4788331bba46ce9593f40f5)