### PR TITLE
Implement interactive mini-survey flow with validation and semantic forms

### DIFF
--- a/test/panel/public/mini-survey-slide-00-overview.html
+++ b/test/panel/public/mini-survey-slide-00-overview.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート概要</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <div class="topbar">
+      <span>サービス: <strong>Panel Research</strong></span>
+      <span class="chip">予定獲得: 100pt</span>
+    </div>
+
+    <header class="header">
+      <h1 class="title">ミニアンケートへようこそ</h1>
+      <p class="subtitle">回答前に概要をご確認ください。</p>
+      <div class="progress-wrap" aria-label="進捗">
+        <div class="progress-meta"><span>開始前</span><span>0%</span></div>
+        <div class="progress"><span style="width: 0%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">イントロ</span>
+      <h2 class="question">このアンケートの目的と参加条件</h2>
+      <p class="help">本調査は、サービス品質向上のための意見収集を目的としています。</p>
+      <ul class="notice-list">
+        <li><strong>目的：</strong>ユーザー体験の改善に向けた基礎データの取得。</li>
+        <li><strong>質問数：</strong>全 <strong>1〜5問</strong> を予定（画面により変動）。</li>
+        <li><strong>回答条件：</strong><strong>全問必須</strong>で回答してください。</li>
+        <li><strong>謝礼：</strong>回答完了で <span class="strong">100pt</span> を付与します。</li>
+        <li><strong>参加回数：</strong><strong>1人1回</strong> までです。</li>
+      </ul>
+      <div class="footer">
+        <button class="btn-secondary" type="button">キャンセル</button>
+        <button class="btn" type="button" data-action="start-survey">アンケートを開始する</button>
+      </div>
+    </section>
+  </main>
+  <script src="mini-survey-slides.js"></script>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-01-single.html
+++ b/test/panel/public/mini-survey-slide-01-single.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 単一選択</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <div class="topbar">
+      <span>サービス: <strong>Panel Research</strong></span>
+      <span class="chip">回答中 / 100pt</span>
+    </div>
+
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問1/4：最も近いものを1つ選択してください。</p>
+      <div class="progress-wrap" aria-label="進捗">
+        <div class="progress-meta"><span>進捗</span><span>25%</span></div>
+        <div class="progress"><span style="width: 25%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Single Choice</span>
+      <form data-form="single">
+        <fieldset>
+          <legend class="question">Q1. あなたが最もよく利用する機能はどれですか？</legend>
+          <p class="help">以下から1つ選択してください（必須）。</p>
+          <div class="field-list">
+            <label class="option"><input type="radio" name="single" required />ダッシュボード</label>
+            <label class="option"><input type="radio" name="single" />アンケート一覧</label>
+            <label class="option"><input type="radio" name="single" />ポイント履歴</label>
+            <label class="option"><input type="radio" name="single" />プロフィール設定</label>
+          </div>
+        </fieldset>
+        <div class="footer">
+          <button class="btn-secondary" type="button" data-back="mini-survey-slide-00-overview.html">戻る</button>
+          <button class="btn" type="submit">回答して次へ</button>
+        </div>
+      </form>
+    </section>
+  </main>
+  <script src="mini-survey-slides.js"></script>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-02-multi.html
+++ b/test/panel/public/mini-survey-slide-02-multi.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 複数選択</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <div class="topbar">
+      <span>サービス: <strong>Panel Research</strong></span>
+      <span class="chip">回答中 / 100pt</span>
+    </div>
+
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問2/4：あてはまる項目をすべて選択してください。</p>
+      <div class="progress-wrap" aria-label="進捗">
+        <div class="progress-meta"><span>進捗</span><span>50%</span></div>
+        <div class="progress"><span style="width: 50%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Multiple Choice</span>
+      <form data-form="multi">
+        <fieldset>
+          <legend class="question">Q2. このサービスの改善に有効だと思う要素を選んでください。</legend>
+          <p class="help">複数選択可能です（1つ以上必須）。</p>
+          <div class="field-list">
+            <label class="option"><input type="checkbox" name="multi" />検索機能の強化</label>
+            <label class="option"><input type="checkbox" name="multi" />通知のカスタマイズ</label>
+            <label class="option"><input type="checkbox" name="multi" />モバイル表示の最適化</label>
+            <label class="option"><input type="checkbox" name="multi" />回答履歴の可視化</label>
+          </div>
+        </fieldset>
+        <div class="footer">
+          <button class="btn-secondary" type="button" data-back="mini-survey-slide-01-single.html">戻る</button>
+          <button class="btn" type="submit">回答して次へ</button>
+        </div>
+      </form>
+    </section>
+  </main>
+  <script src="mini-survey-slides.js"></script>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-03-open-end.html
+++ b/test/panel/public/mini-survey-slide-03-open-end.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 自由記述</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <div class="topbar">
+      <span>サービス: <strong>Panel Research</strong></span>
+      <span class="chip">回答中 / 100pt</span>
+    </div>
+
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問3/4：ご意見を自由にご記入ください。</p>
+      <div class="progress-wrap" aria-label="進捗">
+        <div class="progress-meta"><span>進捗</span><span>75%</span></div>
+        <div class="progress"><span style="width: 75%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Open End</span>
+      <form data-form="open-end">
+        <label class="question" for="open-end-answer">Q3. サービスをより使いやすくするためのご要望を教えてください。</label>
+        <p class="help">具体的な場面や期待する改善内容があればご記入ください（必須）。</p>
+        <textarea id="open-end-answer" required placeholder="例：アンケートの検索条件を保存できると便利です。"></textarea>
+        <div class="footer">
+          <button class="btn-secondary" type="button" data-back="mini-survey-slide-02-multi.html">戻る</button>
+          <button class="btn" type="submit">回答して次へ</button>
+        </div>
+      </form>
+    </section>
+  </main>
+  <script src="mini-survey-slides.js"></script>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slide-04-numeric.html
+++ b/test/panel/public/mini-survey-slide-04-numeric.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ミニアンケート - 数値入力</title>
+  <link rel="stylesheet" href="mini-survey-slides.css" />
+</head>
+<body>
+  <main class="page">
+    <div class="topbar">
+      <span>サービス: <strong>Panel Research</strong></span>
+      <span class="chip">最終設問 / 100pt</span>
+    </div>
+
+    <header class="header">
+      <h1 class="title">ミニアンケート</h1>
+      <p class="subtitle">質問4/4：数値をご入力ください。</p>
+      <div class="progress-wrap" aria-label="進捗">
+        <div class="progress-meta"><span>進捗</span><span>100%</span></div>
+        <div class="progress"><span style="width: 100%"></span></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <span class="badge">Numeric</span>
+      <form data-form="numeric">
+        <label class="question" for="score">Q4. あなたの総合満足度を数値で評価してください。</label>
+        <p class="help">0〜10の範囲で、整数または小数第1位まで入力できます（必須）。</p>
+        <div class="number-group">
+          <input id="score" type="number" min="0" max="10" step="0.1" required placeholder="例：8.5" />
+          <span class="unit">点 / 10点満点</span>
+        </div>
+        <p class="limits">入力範囲: 最小0 / 最大10</p>
+        <div class="footer">
+          <button class="btn-secondary" type="button" data-back="mini-survey-slide-03-open-end.html">戻る</button>
+          <button class="btn" type="submit">回答を送信する</button>
+        </div>
+      </form>
+    </section>
+  </main>
+  <script src="mini-survey-slides.js"></script>
+</body>
+</html>

--- a/test/panel/public/mini-survey-slides.css
+++ b/test/panel/public/mini-survey-slides.css
@@ -1,0 +1,267 @@
+:root {
+  --bg: #f3f6fb;
+  --card: #ffffff;
+  --line: #dce3ef;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --accent: #e8f0ff;
+  --success: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  background: linear-gradient(180deg, #f8fbff 0%, var(--bg) 100%);
+  color: var(--text);
+}
+
+.page {
+  max-width: 760px;
+  margin: 32px auto;
+  padding: 0 16px 40px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.topbar strong {
+  color: #111827;
+}
+
+.chip {
+  background: #eef4ff;
+  border: 1px solid #c9dafd;
+  color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-weight: 600;
+}
+
+.header {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 18px 20px;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.06);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.progress-wrap {
+  margin-top: 14px;
+}
+
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.progress {
+  margin-top: 6px;
+  height: 10px;
+  width: 100%;
+  background: #e6ebf5;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress > span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary), #4f8cff);
+}
+
+.card {
+  margin-top: 16px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.06);
+}
+
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: var(--primary-dark);
+  border: 1px solid #bfd2ff;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.question {
+  margin: 12px 0 6px;
+  font-size: 1.15rem;
+}
+
+
+fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+
+.help {
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.field-list {
+  display: grid;
+  gap: 10px;
+}
+
+.option {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.option:hover {
+  border-color: #9db8f8;
+  background: #f8fbff;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+  margin-top: 2px;
+  transform: scale(1.15);
+}
+
+textarea,
+input[type="number"] {
+  width: 100%;
+  border: 1px solid #bfc8d8;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+textarea:focus,
+input[type="number"]:focus {
+  outline: 2px solid #bdd5ff;
+  border-color: #6fa1ff;
+}
+
+.number-group {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.unit {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.limits {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.footer {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.btn,
+.btn-secondary {
+  border: none;
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.05s, background 0.2s;
+}
+
+.btn {
+  color: #fff;
+  background: var(--primary);
+}
+
+.btn:hover {
+  background: var(--primary-dark);
+}
+
+.btn-secondary {
+  color: #334155;
+  background: #eef2f7;
+  border: 1px solid #d8e0ed;
+}
+
+.btn-secondary:hover {
+  background: #e5ebf4;
+}
+
+.btn:active,
+.btn-secondary:active {
+  transform: translateY(1px);
+}
+
+.notice-list {
+  margin: 14px 0 0;
+  padding-left: 18px;
+  color: #374151;
+}
+
+.notice-list li + li {
+  margin-top: 8px;
+}
+
+.strong {
+  color: var(--success);
+  font-weight: 700;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/test/panel/public/mini-survey-slides.js
+++ b/test/panel/public/mini-survey-slides.js
@@ -1,0 +1,93 @@
+(function () {
+  'use strict';
+
+  function go(url) {
+    window.location.href = url;
+  }
+
+  function handleOverview() {
+    var start = document.querySelector('[data-action="start-survey"]');
+    if (start) {
+      start.addEventListener('click', function () {
+        go('mini-survey-slide-01-single.html');
+      });
+    }
+  }
+
+  function handleSingle() {
+    var form = document.querySelector('[data-form="single"]');
+    if (!form) return;
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      var selected = form.querySelector('input[name="single"]:checked');
+      if (!selected) {
+        alert('1つ選択してください。');
+        return;
+      }
+      go('mini-survey-slide-02-multi.html');
+    });
+  }
+
+  function handleMulti() {
+    var form = document.querySelector('[data-form="multi"]');
+    if (!form) return;
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      var checked = form.querySelectorAll('input[name="multi"]:checked');
+      if (checked.length === 0) {
+        alert('1つ以上選択してください。');
+        return;
+      }
+      go('mini-survey-slide-03-open-end.html');
+    });
+  }
+
+  function handleOpenEnd() {
+    var form = document.querySelector('[data-form="open-end"]');
+    if (!form) return;
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      var text = form.querySelector('#open-end-answer');
+      if (!text || text.value.trim().length === 0) {
+        alert('自由記述を入力してください。');
+        return;
+      }
+      go('mini-survey-slide-04-numeric.html');
+    });
+  }
+
+  function handleNumeric() {
+    var form = document.querySelector('[data-form="numeric"]');
+    if (!form) return;
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      var input = form.querySelector('#score');
+      var value = input ? Number(input.value) : NaN;
+      if (Number.isNaN(value) || value < 0 || value > 10) {
+        alert('0〜10の範囲で入力してください。');
+        return;
+      }
+      alert('ご回答ありがとうございました。100ptを付与しました。');
+      go('survey-complete.html');
+    });
+  }
+
+  function handleBackButtons() {
+    document.querySelectorAll('[data-back]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        go(button.getAttribute('data-back'));
+      });
+    });
+  }
+
+  handleOverview();
+  handleSingle();
+  handleMulti();
+  handleOpenEnd();
+  handleNumeric();
+  handleBackButtons();
+})();


### PR DESCRIPTION
### Motivation
- Turn the static mockup slides into a realistic, production-like mini-survey flow with proper form semantics and client-side validation so QA and developers can use them as realistic samples. 
- Improve accessibility and maintainability by using semantic grouping (`form`/`fieldset`/`legend`/`label`) and consistent shared styles. 

### Description
- Added `test/panel/public/mini-survey-slides.js` to orchestrate navigation (overview → Q1 → Q2 → Q3 → Q4 → complete), back-button behavior, and client-side validation for each page. 
- Updated each slide HTML to include the shared script, add `data-form` and `data-action`/`data-back` attributes, and ensure inputs use semantic markup (radio/checkbox/textarea/number with appropriate `min`/`max`/`step`). 
- Adjusted `test/panel/public/mini-survey-slides.css` to include a `fieldset` reset and preserve visual consistency with the new semantic structure. 

### Testing
- Ran static assertions (`python` script) that verified each HTML page links `mini-survey-slides.css` and `mini-survey-slides.js`, includes the expected `data-form` attributes, and that the numeric input includes `min=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69893aff15e88331bc445ca5e8dcea41)